### PR TITLE
ENG-2593 : Added helm chart for Middleware K8s Agent v2

### DIFF
--- a/charts/mw-kube-agent-v2/.helmignore
+++ b/charts/mw-kube-agent-v2/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/mw-kube-agent-v2/Chart.yaml
+++ b/charts/mw-kube-agent-v2/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: mw-kube-agent-v2
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 2.0.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.1.2"

--- a/charts/mw-kube-agent-v2/templates/_helpers.tpl
+++ b/charts/mw-kube-agent-v2/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "mw-kube-agent.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "mw-kube-agent.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "mw-kube-agent.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "mw-kube-agent.labels" -}}
+helm.sh/chart: {{ include "mw-kube-agent.chart" . }}
+{{ include ".Values.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define ".Values.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mw-kube-agent.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "mw-kube-agent.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "mw-kube-agent.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/mw-kube-agent-v2/templates/clusterrole.yaml
+++ b/charts/mw-kube-agent-v2/templates/clusterrole.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.rbac.create -}}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    {{- include "mw-kube-agent.labels" . | nindent 4 }}
+  name: {{ .Values.clusterRole.name }}
+  namespace: {{.Values.namespace.name}}
+rules:
+  # Allow Metrics Scraper to get metrics from the Metrics server
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["pods", "nodes"]
+    verbs: ["get", "list", "watch"]
+
+  # Other resources
+  - apiGroups: [""]
+    resources: ["nodes", "nodes/stats", "namespaces", "pods", "serviceaccounts", "services", "configmaps", "endpoints", "persistentvolumeclaims", "replicationcontrollers", "replicationcontrollers/scale", "persistentvolumeclaims", "persistentvolumes", "bindings", "events", "limitranges", "namespaces/status", "pods/log", "pods/status", "replicationcontrollers/status", "resourcequotas", "resourcequotas/status"]
+    verbs: ["get", "list", "watch"]
+  
+  - apiGroups: ["apps"]
+    resources: ["daemonsets", "deployments", "deployments/scale", "replicasets", "replicasets/scale", "statefulsets"]
+    verbs: ["get", "list", "watch", "patch"]
+
+  - apiGroups: ["autoscaling"]
+    resources: ["horizontalpodautoscalers"]
+    verbs: ["get", "list", "watch"]
+
+  - apiGroups: ["batch"]
+    resources: ["cronjobs", "jobs"]
+    verbs: ["get", "list", "watch"]
+
+  - apiGroups: ["extensions"]
+    resources: ["daemonsets", "deployments", "deployments/scale", "networkpolicies", "replicasets", "replicasets/scale", "replicationcontrollers/scale"]
+    verbs: ["get", "list", "watch"]
+
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses", "networkpolicies"]
+    verbs: ["get", "list", "watch"]
+
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["get", "list", "watch"]
+
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses", "volumeattachments"]
+    verbs: ["get", "list", "watch"]
+
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["clusterrolebindings", "clusterroles", "roles", "rolebindings", ]
+    verbs: ["get", "list", "watch"]
+{{- end }}

--- a/charts/mw-kube-agent-v2/templates/clusterrolebinding.yaml
+++ b/charts/mw-kube-agent-v2/templates/clusterrolebinding.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{.Values.clusterRoleBinding.name}}
+  namespace: {{.Values.namespace.name}}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{.Values.clusterRole.name}}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "mw-kube-agent.serviceAccountName" . }}
+    namespace: {{.Values.namespace.name}}
+{{- end }}

--- a/charts/mw-kube-agent-v2/templates/configmap-daemonset.yaml
+++ b/charts/mw-kube-agent-v2/templates/configmap-daemonset.yaml
@@ -1,0 +1,341 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.daemonset.configMap.name }}
+  namespace: {{.Values.namespace.name}}
+  labels:
+    {{- include "mw-kube-agent.labels" . | nindent 4 }}
+data:
+  otel-config: |
+    receivers:
+      filelog:
+        include: [ /var/log/pods/*/*/*.log, $MW_LOG_PATHS ]
+        include_file_path: true
+        include_file_name_resolved: true
+        include_file_path_resolved: true
+        start_at: beginning
+        multiline:
+          line_start_pattern: ^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:?\d{2})?\s+(stdout|stderr)?\s?(\[.+?\])?\s+(.+)$
+        operators:
+          # Find out which format is used by kubernetes
+          - type: router
+            id: get-format
+            routes:
+              - output: parser-docker
+                expr: 'body matches "^\\{"'
+              - output: parser-crio
+                expr: 'body matches "^[^ Z]+ "'
+              - output: parser-containerd
+                expr: 'body matches "^[^ Z]+Z"'
+          # Parse CRI-O format
+          - type: regex_parser
+            id: parser-crio
+            regex: '^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$'
+            output: extract_metadata_from_filepath
+            timestamp:
+              parse_from: attributes.time
+              layout_type: gotime
+              layout: '2006-01-02T15:04:05.000000000-07:00'
+          # Parse CRI-Containerd format
+          - type: regex_parser
+            id: parser-containerd
+            regex: '^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$'
+            output: extract_metadata_from_filepath
+            timestamp:
+              parse_from: attributes.time
+              layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+          # Parse Docker format
+          - type: json_parser
+            id: parser-docker
+            output: extract_metadata_from_filepath
+            timestamp:
+              parse_from: attributes.time
+              layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+          # Extract metadata from file path
+          - type: regex_parser
+            id: extract_metadata_from_filepath
+            regex: '^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]{36})\/(?P<container_name>[^\._]+)\/(?P<restart_count>\d+)\.log$'
+            parse_from: attributes["log.file.path"]
+            output: move_log_to_body
+          - type: move
+            id: move_log_to_body
+            from: attributes.log
+            to: body
+            output: adding_regex_to_attributes
+          # Applying custom patterns for beautifying logs :
+          # -------------------------------------
+          # 1. Rules for beautifying systemd logs
+          # -------------------------------------
+          # If systemd pattern matches -- add systemd regex to attributes
+          - type: add
+            if: 'body matches "ts=.+ caller=.+ level=.+ msg=.+ name=systemd duration_seconds=.+ err=.+"'
+            id: adding_regex_to_attributes
+            field: attributes.regex_identified
+            value: ts=.+ caller=.+ level=.+ msg=.+ name=systemd duration_seconds=.+ err=.+
+            output: systemd_err
+          # If systemd pattern matches parsing details from body to attributes
+          - type: regex_parser
+            if: 'body matches "ts=.+ caller=.+ level=.+ msg=.+ name=systemd duration_seconds=.+ err=.+"'
+            id: systemd_err
+            regex:  'ts=(?P<systemd_err_ts>.+) caller=(?P<systemd_err_caller>.+) level=(?P<level>.+) msg=(?P<systemd_err_msg>.+) name=(?P<name>.+) duration_seconds=(?P<systemd_err_duration_seconds>.+) err="(?P<regex_resolved_body>.+)"'
+            parse_from: body
+            output: backup_unresolved_body
+          # Copying unresolved regex body to attributes
+          - type: copy
+            id: backup_unresolved_body
+            if: "attributes.regex_resolved_body != nil"
+            from: body
+            to: attributes.regex_unresolved_body
+            output: systemd_err_move
+          #  Moving systemd error content from attributes to body
+          - type: move
+            id: systemd_err_move
+            if: "attributes.regex_resolved_body != nil"
+            from: attributes.regex_resolved_body
+            to: body
+      kubeletstats:
+        collection_interval: 15s
+        auth_type: serviceAccount
+        endpoint: "${K8S_NODE_IP}:10250"
+        insecure_skip_verify: true
+        k8s_api_config:
+          auth_type: serviceAccount
+        extra_metadata_labels: [container.id, k8s.volume.type]
+      hostmetrics:
+        collection_interval: 5s
+        scrapers:
+          cpu:
+            metrics:
+              system.cpu.utilization:
+                enabled: true
+          load:
+            cpu_average: true
+          memory:
+            metrics:
+              system.memory.utilization:
+                enabled: true
+          paging: {}
+          disk:
+            metrics:
+              system.disk.io.speed:
+                enabled: true
+          filesystem:
+            metrics:
+              system.filesystem.utilization:
+                enabled: true
+          network:
+            metrics:
+              system.network.io.bandwidth:
+                enabled: true
+          processes: {}
+          process:
+            mute_process_name_error: true
+      
+      prometheus:
+        config:
+          scrape_configs:
+            - job_name: "otel-collector"
+              scrape_interval: 5s
+              static_configs:
+                - targets: ["0.0.0.0:8888"]
+      
+      fluentforward:
+        endpoint: 0.0.0.0:8006
+      # kubeletstats:
+      #   ceat_path:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:9319
+            # max_recv_msg_size_mib: 8
+          http:
+            endpoint: 0.0.0.0:9320
+    exporters:
+      logging:
+        loglevel: fatal
+      otlp:
+        endpoint: ${MW_TARGET}
+    processors:
+      k8sattributes:
+        auth_type: "serviceAccount"
+        passthrough: false
+        filter:
+          node_from_env_var: KUBE_NODE_NAME
+        extract:
+          metadata:
+            - k8s.pod.name
+            - k8s.pod.uid
+            - k8s.deployment.name
+            - k8s.namespace.name
+            - k8s.node.name
+            - k8s.pod.start_time
+        pod_association:
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.ip
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.uid
+          - sources:
+            - from: connection
+      resource:
+        attributes:
+          - key: host.id
+            from_attribute: host.name
+            action: upsert
+          - key: mw.account_key
+            action: insert
+            value: ${MW_API_KEY}
+          - key: agent.installation.time
+            from_attribute: host.name
+            action: insert
+          - key: agent.installation.time
+            value: ${MW_AGENT_INSTALLATION_TIME}
+            action: update
+          - key: k8s.cluster.name
+            from_attribute: k8s.node.uid
+            action: insert
+          - key: k8s.cluster.name
+            from_attribute: k8s.namespace.uid
+            action: insert
+          - key: k8s.cluster.name
+            from_attribute: k8s.pod.uid
+            action: insert
+          - key: k8s.cluster.name
+            from_attribute: k8s.container.name
+            action: insert
+          - key: k8s.cluster.name
+            from_attribute: k8s.replicaset.uid
+            action: insert
+          - key: k8s.cluster.name
+            from_attribute: k8s.statefulset.uid
+            action: insert
+          - key: k8s.cluster.name
+            from_attribute: k8s.cronjob.uid
+            action: insert
+          - key: k8s.cluster.name
+            from_attribute: k8s.job.uid
+            action: insert
+          - key: k8s.cluster.name
+            from_attribute: k8s.daemonset.uid
+            action: insert
+          - key: k8s.cluster.name
+            from_attribute: k8s.deployment.uid
+            action: insert
+      resource/hostmetrics:
+        attributes:
+          - key: is.k8s.node
+            action: insert
+            value: "yes"
+      
+      resource/cluster:
+        attributes:
+          - key: k8s.cluster.name
+            action: update
+            value: ${MW_KUBE_CLUSTER_NAME}
+          - key: host.id
+            action: update
+            from_attribute: k8s.node.name
+          - key: host.name
+            action: update
+            from_attribute: k8s.node.name
+      
+      resource/logs:
+        attributes:
+          - key: service.name
+            action: insert
+            value: middleware-logs
+
+      resourcedetection:
+        detectors: [ env, system, docker ]
+        system:
+          hostname_sources: ["os"]
+        timeout: 2s
+        override: false
+      batch:
+      batch/2:
+        send_batch_size: 2000
+        timeout: 10s
+      attributes/traces:
+        actions:
+          - key: mw.service.name.derived
+            from_attribute: db.system
+            action: insert
+          - key: mw.service.name.derived
+            from_attribute: messaging.system
+            action: insert
+          - key: mw.service.name.derived
+            from_attribute: rpc.system
+            action: insert
+          - key: mw.service.name.derived
+            from_attribute: http.scheme
+            action: insert
+          - key: mw.service.name.derived
+            from_attribute: faas.trigger
+            action: insert
+      attributes/logs:
+        actions:
+          - key: source
+            from_attribute: name
+            action: upsert
+          - key: source
+            from_attribute: operator_type
+            action: upsert
+          - key: source
+            from_attribute: log.file.name
+            action: upsert
+          - key: source
+            from_attribute: fluent.tag
+            action: upsert
+          - key: source
+            from_attribute: service.name
+            action: upsert
+          - key: source
+            from_attribute: project.name
+            action: upsert
+          - key: source
+            from_attribute: serviceName
+            action: upsert
+          - key: source
+            from_attribute: projectName
+            action: upsert
+          - key: source
+            from_attribute: pod_name
+            action: upsert
+          - key: source
+            from_attribute: container_name
+            action: upsert
+          - key: source
+            from_attribute: namespace
+            action: upsert 
+    service:
+        telemetry:
+          logs:
+            level: "fatal"
+          metrics:
+            address: 0.0.0.0:8888
+        pipelines:
+          traces/otlp:
+            receivers: [ otlp ]
+            processors: [ resourcedetection,resource, resource/cluster, attributes/traces, batch, batch/2 ]
+            exporters: [  otlp ]
+          logs/fluentforward:
+            receivers: [ fluentforward ]
+            processors: [ resourcedetection, resource, resource/cluster, attributes/logs, resource/logs, k8sattributes, batch, batch/2 ]
+            exporters: [ otlp ]
+          logs/otlp:
+            receivers: [ otlp ]
+            processors: [ resourcedetection, resource, resource/cluster, attributes/logs, resource/logs, k8sattributes, batch, batch/2 ]
+            exporters: [ otlp ]
+          logs/filelog:
+            receivers: [ filelog ]
+            processors: [ resourcedetection, resource, resource/cluster, attributes/logs, resource/logs, k8sattributes, batch, batch/2 ]
+            exporters: [ otlp ]
+          metrics/kubeletstats:
+            receivers: [ kubeletstats ]
+            processors: [ resourcedetection, resource, k8sattributes, resource/cluster, batch, batch/2]
+            exporters: [ otlp, logging ]
+          metrics/hostmetrics:
+            receivers: [ hostmetrics ]
+            processors: [ resourcedetection, resource, resource/hostmetrics, resource/cluster, k8sattributes, batch, batch/2]
+            exporters: [ otlp ]

--- a/charts/mw-kube-agent-v2/templates/configmap-deployment.yaml
+++ b/charts/mw-kube-agent-v2/templates/configmap-deployment.yaml
@@ -1,0 +1,222 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.deployment.configMap.name }}
+  namespace: {{.Values.namespace.name}}
+  labels:
+    {{- include "mw-kube-agent.labels" . | nindent 4 }}
+data:
+  otel-config: |
+    receivers:
+      k8s_cluster:
+        auth_type: serviceAccount
+        collection_interval: 15s
+        node_conditions_to_report: [ Ready, DiskPressure, MemoryPressure, PIDPressure, NetworkUnavailable ]
+        distribution: kubernetes
+        allocatable_types_to_report: [ cpu, memory, ephemeral-storage, storage ]
+      
+      prometheus:
+        config:
+          scrape_configs:
+            - job_name: "otel-collector"
+              scrape_interval: 5s
+              static_configs:
+                - targets: ["0.0.0.0:8888"]
+      
+      fluentforward:
+        endpoint: 0.0.0.0:8006
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:9319
+          http:
+            endpoint: 0.0.0.0:9320
+    exporters:
+      logging:
+        loglevel: warn
+      otlp:
+        endpoint: ${MW_TARGET}
+    processors:
+      k8sattributes:
+        auth_type: "serviceAccount"
+        passthrough: false
+        filter:
+          node_from_env_var: KUBE_NODE_NAME
+        extract:
+          metadata:
+            - k8s.pod.name
+            - k8s.pod.uid
+            - k8s.deployment.name
+            - k8s.namespace.name
+            - k8s.node.name
+            - k8s.pod.start_time
+        pod_association:
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.ip
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.uid
+          - sources:
+            - from: connection
+      resource:
+        attributes:
+          - key: host.id
+            from_attribute: host.name
+            action: upsert
+          - key: mw.account_key
+            action: insert
+            value: ${MW_API_KEY}
+          - key: agent.installation.time
+            from_attribute: host.name
+            action: insert
+          - key: agent.installation.time
+            value: ${MW_AGENT_INSTALLATION_TIME}
+            action: update
+          - key: k8s.cluster.name
+            from_attribute: k8s.node.uid
+            action: insert
+          - key: k8s.cluster.name
+            from_attribute: k8s.namespace.uid
+            action: insert
+          - key: k8s.cluster.name
+            from_attribute: k8s.pod.uid
+            action: insert
+          - key: k8s.cluster.name
+            from_attribute: k8s.container.name
+            action: insert
+          - key: k8s.cluster.name
+            from_attribute: k8s.replicaset.uid
+            action: insert
+          - key: k8s.cluster.name
+            from_attribute: k8s.statefulset.uid
+            action: insert
+          - key: k8s.cluster.name
+            from_attribute: k8s.cronjob.uid
+            action: insert
+          - key: k8s.cluster.name
+            from_attribute: k8s.job.uid
+            action: insert
+          - key: k8s.cluster.name
+            from_attribute: k8s.daemonset.uid
+            action: insert
+          - key: k8s.cluster.name
+            from_attribute: k8s.deployment.uid
+            action: insert
+      resource/hostmetrics:
+        attributes:
+          - key: is.k8s.node
+            action: insert
+            value: "yes"
+      
+      resource/cluster:
+        attributes:
+          - key: k8s.cluster.name
+            action: update
+            value: ${MW_KUBE_CLUSTER_NAME}
+          - key: host.id
+            action: update
+            from_attribute: k8s.node.name
+          - key: host.name
+            action: update
+            from_attribute: k8s.node.name
+      
+      resource/logs:
+        attributes:
+          - key: service.name
+            action: insert
+            value: middleware-logs
+
+      resourcedetection:
+        detectors: [ env, system, docker ]
+        system:
+          hostname_sources: ["os"]
+        timeout: 2s
+        override: false
+      batch:
+      batch/2:
+        send_batch_size: 2000
+        timeout: 10s
+      attributes/traces:
+        actions:
+          - key: mw.service.name.derived
+            from_attribute: db.system
+            action: insert
+          - key: mw.service.name.derived
+            from_attribute: messaging.system
+            action: insert
+          - key: mw.service.name.derived
+            from_attribute: rpc.system
+            action: insert
+          - key: mw.service.name.derived
+            from_attribute: http.scheme
+            action: insert
+          - key: mw.service.name.derived
+            from_attribute: faas.trigger
+            action: insert
+      attributes/logs:
+        actions:
+          - key: source
+            from_attribute: name
+            action: upsert
+          - key: source
+            from_attribute: operator_type
+            action: upsert
+          - key: source
+            from_attribute: log.file.name
+            action: upsert
+          - key: source
+            from_attribute: fluent.tag
+            action: upsert
+          - key: source
+            from_attribute: service.name
+            action: upsert
+          - key: source
+            from_attribute: project.name
+            action: upsert
+          - key: source
+            from_attribute: serviceName
+            action: upsert
+          - key: source
+            from_attribute: projectName
+            action: upsert
+          - key: source
+            from_attribute: pod_name
+            action: upsert
+          - key: source
+            from_attribute: container_name
+            action: upsert
+          - key: source
+            from_attribute: namespace
+            action: upsert 
+    service:
+        telemetry:
+          logs:
+            level: "fatal"
+          metrics:
+            address: 0.0.0.0:8888
+        pipelines:
+          traces/otlp:
+            receivers: [ otlp ]
+            processors: [ resourcedetection,resource, resource/cluster, attributes/traces, batch, batch/2 ]
+            exporters: [  otlp ]
+          logs/fluentforward:
+            receivers: [ fluentforward ]
+            processors: [ resourcedetection, resource, resource/cluster, attributes/logs, resource/logs, k8sattributes, batch, batch/2 ]
+            exporters: [ otlp ]
+          logs/otlp:
+            receivers: [ otlp ]
+            processors: [ resourcedetection, resource, resource/cluster, attributes/logs, resource/logs, k8sattributes, batch, batch/2 ]
+            exporters: [ otlp ]
+          metrics/prometheus:
+            receivers: [ prometheus ]
+            processors: [ resourcedetection, resource, k8sattributes, resource/cluster, batch, batch/2]
+            exporters: [ otlp ]
+          metrics/otlp:
+            receivers: [ otlp ]
+            processors: [ resourcedetection, resource, k8sattributes, resource/cluster, batch, batch/2]
+            exporters: [ otlp ]
+          metrics/k8s_cluster:
+            receivers: [ k8s_cluster ]
+            processors: [ resourcedetection, resource, k8sattributes, resource/cluster, batch, batch/2]
+            exporters: [ otlp ]

--- a/charts/mw-kube-agent-v2/templates/cronjob.yaml
+++ b/charts/mw-kube-agent-v2/templates/cronjob.yaml
@@ -1,0 +1,42 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: mw-kube-agent-update
+  namespace: {{.Values.namespace.name}}
+spec:
+  schedule: "*/1 * * * *"  # Adjust the schedule as needed
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: mw-app
+            k8s-app: mw-app
+        spec:
+          tolerations:
+            - key: node-role.kubernetes.io/control-plane
+              effect: NoSchedule
+            - key: node-role.kubernetes.io/master
+              effect: NoSchedule
+          containers:
+            - name: mw-kube-agent
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+              imagePullPolicy: Always
+              args:
+                - mw-agent
+                - update
+              env:
+                - name: MW_TARGET
+                  value: {{ .Values.mw.target }}
+                - name: MW_API_URL_FOR_CONFIG_CHECK
+                  value: "MW_API_URL_FOR_CONFIG_CHECK_VALUE"
+                - name: MW_CONFIG_CHECK_INTERVAL
+                  value: "MW_CONFIG_CHECK_INTERVAL_VALUE"
+                - name: MW_KUBE_CLUSTER_NAME
+                  value: "MW_KUBE_CLUSTER_NAME_VALUE"
+                - name: MW_API_KEY
+                  value: {{ .Values.mw.apikey }}
+              securityContext:
+                privileged: true
+          restartPolicy: OnFailure
+          serviceAccountName: mw-service-account-update

--- a/charts/mw-kube-agent-v2/templates/daemonset.yaml
+++ b/charts/mw-kube-agent-v2/templates/daemonset.yaml
@@ -1,0 +1,86 @@
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: {{ .Values.daemonset.name }}
+  namespace: {{.Values.namespace.name}}
+spec:
+  selector:
+    matchLabels:
+      {{- include ".Values.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include ".Values.selectorLabels" . | nindent 8 }}
+    spec:
+      tolerations:
+      # these tolerations are to have the daemonset runnable on control plane nodes
+      # remove them if your control plane nodes should not run pods
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      - operator: Exists
+        effect: NoSchedule
+      - operator: Exists
+        effect: NoExecute
+      volumes:
+      - name: mw-daemonset-otel-config-volume
+        configMap:
+          name: mw-daemonset-otel-config
+          items:
+            - key: otel-config
+              path: otel-config-daemonset.yaml
+      # volume binding for log collection 
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: varrun
+        hostPath:
+          path: /var/run/docker.sock
+      - name: runcontainerd
+        hostPath:
+          path: /run/containerd/containerd.sock
+      # volume binding for log collection
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers
+      containers:
+        - args:
+          - mw-agent
+          - start
+          - --otel-config-file
+          - /app/otel-config-daemonset.yaml
+          env:
+            - name: MW_TARGET
+              value: {{ .Values.mw.target }}
+            - name: MW_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: middleware-secret
+                  key: api-key
+          resources:
+          {{- toYaml .Values.resources | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          name: {{ .Chart.Name }}
+          securityContext:
+            privileged: true
+          volumeMounts:
+          - name: mw-daemonset-otel-config-volume
+            mountPath: /app
+          - mountPath: /var/log
+            name: varlog
+            readOnly: true
+          - mountPath: /var/run/docker.sock
+            name: varrun
+            readOnly: true
+          - mountPath: /run/containerd/containerd.sock
+            name: runcontainerd
+            readOnly: true
+          - mountPath: /var/lib/docker/containers
+            name: varlibdockercontainers
+            readOnly: true
+      restartPolicy: Always
+      serviceAccountName: {{ include "mw-kube-agent.serviceAccountName" . }}

--- a/charts/mw-kube-agent-v2/templates/deployment.yaml
+++ b/charts/mw-kube-agent-v2/templates/deployment.yaml
@@ -1,0 +1,61 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: {{ .Values.deployment.name }}
+  namespace: {{.Values.namespace.name}}
+spec:
+  selector:
+    matchLabels:
+      {{- include ".Values.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include ".Values.selectorLabels" . | nindent 8 }}
+    spec:
+      tolerations:
+      # these tolerations are to have the daemonset runnable on control plane nodes
+      # remove them if your control plane nodes should not run pods
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      - operator: Exists
+        effect: NoSchedule
+      - operator: Exists
+        effect: NoExecute
+
+      volumes:
+        - name: mw-deployment-otel-config-volume
+          configMap:
+            name: mw-deployment-otel-config
+            items:
+              - key: otel-config
+                path: otel-config-deployment.yaml
+      containers:
+        - args:
+            - mw-agent
+            - start
+            - --otel-config-file
+            - /app/otel-config-deployment.yaml
+          volumeMounts:
+            - name: mw-deployment-otel-config-volume
+              mountPath: /app
+          env:
+            - name: MW_TARGET
+              value: {{ .Values.mw.target }}
+            - name: MW_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: middleware-secret
+                  key: api-key
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          name: {{ .Chart.Name }}
+          securityContext:
+            privileged: true
+      restartPolicy: Always
+      serviceAccountName: {{ include "mw-kube-agent.serviceAccountName" . }}

--- a/charts/mw-kube-agent-v2/templates/role.yaml
+++ b/charts/mw-kube-agent-v2/templates/role.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.rbac.create -}}
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    {{- include "mw-kube-agent.labels" . | nindent 4 }}
+  name: {{ .Values.role.name }}
+  namespace: {{.Values.namespace.name}}
+rules:
+  # Allow Dashboard to get, update and delete Dashboard exclusive secrets.
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: [{{ .Values.secret.certSecretName }}, {{ .Values.secret.csrfSecretName }}, {{ .Values.secret.keyHolderSecretName }}]
+    verbs: ["get", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["pods", "pods/exec"]
+    verbs: ["get", "list", "delete", "patch", "create"]
+    # Allow Dashboard to get and update 'mw-app-settings' config map.
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: [{{ .Values.daemonset.configMap.name }}, {{ .Values.deployment.configMap.name }}]
+    verbs: ["get", "update"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+    # Allow Dashboard to get metrics.
+  - apiGroups: [""]
+    resources: ["services"]
+    resourceNames: ["heapster", "dashboard-metrics-scraper"]
+    verbs: ["proxy"]
+  - apiGroups: [""]
+    resources: ["services/proxy"]
+    resourceNames: ["heapster", "http:heapster:", "https:heapster:", "dashboard-metrics-scraper", "http:dashboard-metrics-scraper"]
+    verbs: ["get"]
+{{- end }}

--- a/charts/mw-kube-agent-v2/templates/rolebinding.yaml
+++ b/charts/mw-kube-agent-v2/templates/rolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Values.roleBinding.name }}
+  namespace: {{.Values.namespace.name}}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Values.role.name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "mw-kube-agent.serviceAccountName" . }}
+    namespace: {{.Values.namespace.name}}
+
+{{- end }}

--- a/charts/mw-kube-agent-v2/templates/secret.yaml
+++ b/charts/mw-kube-agent-v2/templates/secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: middleware-secret
+  namespace: {{ .Values.namespace.name }}
+  labels:
+      {{- include "mw-kube-agent.labels" . | nindent 4 }}
+type: Opaque
+
+data:
+  api-key: {{ .Values.mw.apiKey | b64enc | quote }}

--- a/charts/mw-kube-agent-v2/templates/service.yaml
+++ b/charts/mw-kube-agent-v2/templates/service.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.service.name }}
+  namespace: {{.Values.namespace.name}}
+  labels:
+    {{- include "mw-kube-agent.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.grpc.port }}
+      targetPort: {{ .Values.service.grpc.targetPort }}
+      name: grpc
+    - port: {{ .Values.service.grpc2.port }}
+      targetPort: {{ .Values.service.grpc2.targetPort }}
+      name: grpc2
+    - port: {{ .Values.service.http.port }}
+      targetPort: {{ .Values.service.http.targetPort }}
+      name: http
+    - port: {{ .Values.service.fluent.port }}
+      targetPort: {{ .Values.service.fluent.targetPort }}
+      name: fluent
+  selector:
+    {{- include ".Values.selectorLabels" . | nindent 4 }}

--- a/charts/mw-kube-agent-v2/templates/serviceaccount.yaml
+++ b/charts/mw-kube-agent-v2/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "mw-kube-agent.serviceAccountName" . }}
+  namespace: {{.Values.namespace.name}}
+  labels:
+    {{- include "mw-kube-agent.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/mw-kube-agent-v2/values.yaml
+++ b/charts/mw-kube-agent-v2/values.yaml
@@ -1,0 +1,90 @@
+# Default values for mw-kube-agent.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+mw:
+  target: XXXXXXXXX
+  apiKey: XXXXXXXXX
+
+replicaCount: 1
+
+image:
+  repository: ghcr.io/middleware-labs/mw-kube-agent
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: 1.6.4
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+rbac:
+  create: true
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: mw-service-account
+
+namespace:
+  name: mw-agent-ns
+  
+secret: 
+  type: Opaque
+  certSecretName: mw-app-certs
+  csrfSecretName: mw-app-csrf
+  keyHolderSecretName: mw-app-key-holder
+
+
+
+role:
+  name: mw-role
+
+roleBinding:
+  name: mw-role-binding
+
+clusterRole:
+  name: mw-cluster-role
+
+clusterRoleBinding:
+  name: mw-cluster-role-binding
+
+service:
+  name: mw-kube-agent-svc
+  type: NodePort
+  http:
+    port: 9320
+    targetPort: 9320
+  grpc:
+    port: 443 
+    targetPort: 8443
+  grpc2:
+    port: 9319
+    targetPort: 9319
+  fluent:
+    port: 8006
+    targetPort: 8006
+  
+daemonset:
+  name: mw-kube-agent
+  configMap:
+    name: mw-daemonset-otel-config
+deployment:
+  name: mw-kube-agent
+  configMap:
+    name: mw-deployment-otel-config
+
+resources:
+  requests:
+    cpu: "100m"   # Default CPU request
+    memory: "128Mi"  # Default memory request
+  limits:
+    cpu: "200m"   # Default CPU limit
+    memory: "256Mi"  # Default memory limit
+
+selectorLabels:
+  k8s-app: mw-app


### PR DESCRIPTION
Additional to functionalities like K8s Agent v1 Helm chart, This includes ...
1. Support for adding `resources` via helm values
2. Support for passing MW_API_KEY as a secret

Helm chart can be tested with this command 

`helm install mw-kube-agent-v2 ./mw-kube-agent-v2  --set-string mw.apiKey=XXXXXXXXXX --set-string mw.target=https://XXXXX.middleware.io`

