### PR TITLE
Allowing to read MW_API_KEY from a custom secret

### DIFF
--- a/charts/mw-kube-agent-v2/Chart.yaml
+++ b/charts/mw-kube-agent-v2/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.2
+version: 2.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/mw-kube-agent-v2/templates/cronjob.yaml
+++ b/charts/mw-kube-agent-v2/templates/cronjob.yaml
@@ -34,11 +34,19 @@ spec:
                   value: {{ .Values.clusterMetadata.name }}
                 - name: MW_NAMESPACE
                   value: {{ .Values.namespace.name }}
+                {{- if .Values.mw.apiKeyFromExistingSecret.enabled }}
+                - name: MW_API_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.mw.apiKeyFromExistingSecret.name }}
+                      key: {{ .Values.mw.apiKeyFromExistingSecret.key }}
+                {{- else }}
                 - name: MW_API_KEY
                   valueFrom:
                     secretKeyRef:
                       name: middleware-secret
                       key: api-key
+                {{- end }}
               securityContext:
                 privileged: true
           restartPolicy: OnFailure

--- a/charts/mw-kube-agent-v2/templates/daemonset.yaml
+++ b/charts/mw-kube-agent-v2/templates/daemonset.yaml
@@ -68,11 +68,19 @@ spec:
               value: {{ .Values.mw.selfProfiling | quote }}
             - name: MW_PROFILING_SERVER_URL
               value: {{ .Values.mw.profilingServerUrl | quote}}
+            {{- if .Values.mw.apiKeyFromExistingSecret.enabled }}
+            - name: MW_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.mw.apiKeyFromExistingSecret.name }}
+                  key: {{ .Values.mw.apiKeyFromExistingSecret.key }}
+            {{- else }}
             - name: MW_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: middleware-secret
                   key: api-key
+            {{- end }}
           resources:
           {{- toYaml .Values.resources | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/mw-kube-agent-v2/templates/deployment.yaml
+++ b/charts/mw-kube-agent-v2/templates/deployment.yaml
@@ -55,11 +55,19 @@ spec:
               value: {{ .Values.mw.selfProfiling | quote }}
             - name: MW_PROFILING_SERVER_URL
               value: {{ .Values.mw.profilingServerUrl | quote }}
+            {{- if .Values.mw.apiKeyFromExistingSecret.enabled }}
+            - name: MW_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.mw.apiKeyFromExistingSecret.name }}
+                  key: {{ .Values.mw.apiKeyFromExistingSecret.key }}
+            {{- else }}
             - name: MW_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: middleware-secret
                   key: api-key
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/mw-kube-agent-v2/templates/secret.yaml
+++ b/charts/mw-kube-agent-v2/templates/secret.yaml
@@ -8,20 +8,4 @@ metadata:
 type: Opaque
 
 data:
-  api-key: {{- if .Values.mw.apiKeyFromExistingSecret.enabled }}
-             {{- $secretName := $.Values.mw.apiKeyFromExistingSecret.name }}
-             {{- $secretKey := $.Values.mw.apiKeyFromExistingSecret.key }}
-             {{- $namespace := $.Values.namespace.name }}
-             {{- $secret := lookup "v1" "Secret" $namespace $secretName }}
-             {{- if $secret}}
-               {{- $apiKey := index $secret.data $secretKey }}
-               {{- if $apiKey }}
-                 {{ $apiKey }}
-               {{- else }}
-                 {{- fail "Could not read MW API Key from existing secret" }}
-               {{- end }}
-             {{- end }}
-             
-           {{- else }}
-             {{ .Values.mw.apiKey | toString | b64enc }}   
-           {{- end }}
+  api-key: {{ .Values.mw.apiKey | b64enc | quote }}


### PR DESCRIPTION
In the earlier PR for the same usecase : https://github.com/middleware-labs/helm-charts/pull/20
Old Approach was :
custom secret > middleware-secret > MW_API_KEY Env variable

New Approach :
custom secret > MW_API_KEY Env variable
If custom secret is provided we are skipping to create `middleware-secret`