### PR TITLE
Adding blank configmaps in templates

### DIFF
--- a/charts/mw-kube-agent-v3/templates/configmap-daemonset.yaml
+++ b/charts/mw-kube-agent-v3/templates/configmap-daemonset.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.daemonset.configMap.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mw-kube-agent.labels" . | nindent 4 }}
+data:
+  otel-config: |

--- a/charts/mw-kube-agent-v3/templates/configmap-deployment.yaml
+++ b/charts/mw-kube-agent-v3/templates/configmap-deployment.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.deployment.configMap.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mw-kube-agent.labels" . | nindent 4 }}
+data:
+  otel-config: |


### PR DESCRIPTION
Currently, deleting the helm chart is not cleaning up configmaps
Due to this, sometimes older configs are applied to k8s agent.

Adding configmaps to templates will make sure that configmaps are deleted with k8s agent helm chart uninstallation.