### PR TITLE
Setting Default java instrumentation Protocol to grpc

### DIFF
--- a/.github/workflows/helm-release-instrument.yaml
+++ b/.github/workflows/helm-release-instrument.yaml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - master
+    paths:
+      - 'charts/mw-autoinstrumentation/**'
 
 jobs:
   release:

--- a/.github/workflows/helm-release-k8s-agent.yaml
+++ b/.github/workflows/helm-release-k8s-agent.yaml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - master
+    paths:
+      - 'charts/mw-kube-agent-v3/**'
 
 jobs:
   release:

--- a/charts/mw-autoinstrumentation/Chart.lock
+++ b/charts/mw-autoinstrumentation/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: opentelemetry-operator
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  version: 0.92.0
-digest: sha256:4b63d032d68c5b26175bd0241f47a8be36f0a2db2e67a457dc4f75e8f3dc4533
-generated: "2025-07-21T22:21:58.69933293+05:30"
+  version: 0.75.1
+digest: sha256:3a0a1fc4f96086e129c2cfabdee6d429fa7a1f7a37aec8d25498aab866febde2
+generated: "2025-08-26T16:45:57.477899393+05:30"

--- a/charts/mw-autoinstrumentation/Chart.yaml
+++ b/charts/mw-autoinstrumentation/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v2
 name: mw-autoinstrumentation
 description: Middleware Auto-instrumentation Helm Chart
-version: 1.0.1
+version: 1.0.2
 type: application
 dependencies:
   - name: opentelemetry-operator
-    version: "*"
+    version: "0.75.1"
     repository: "https://open-telemetry.github.io/opentelemetry-helm-charts"
     condition: opentelemetry-operator.enabled
     namespace: opentelemetry-operator-system 

--- a/charts/mw-autoinstrumentation/templates/instrument.yaml
+++ b/charts/mw-autoinstrumentation/templates/instrument.yaml
@@ -38,3 +38,5 @@ spec:
         value: mw-service.{{ .Release.Namespace }}.svc.cluster.local
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: http://mw-service.{{ .Release.Namespace }}:9319
+      - name: OTEL_EXPORTER_OTLP_PROTOCOL
+        value: grpc


### PR DESCRIPTION
- Setting `OTEL_EXPORTER_OTLP_PROTOCOL` to `grpc` forcefully, for Java
- Hardcoding opentelemetry operator dependency to `0.75.1`
- Updated Helm chart release workflow to trigger only when particular charts are updated