### PR TITLE
Helm Release 1.7.4

### DIFF
--- a/charts/mw-kube-agent-v3/Chart.lock
+++ b/charts/mw-kube-agent-v3/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mw-autoinstrumentation
   repository: https://helm.middleware.io
-  version: 1.2.5
-digest: sha256:aead3e8fd5eb9e558e998a774d3f222702661d84ec82675c9cbd504ce43828ec
-generated: "2026-04-01T14:45:59.694672053+05:30"
+  version: 1.2.6
+digest: sha256:08d960ef5aaa9c123e316599c3254d00f38a23008780a592ed966f22db41b397
+generated: "2026-05-07T12:23:38.799595475+05:30"

--- a/charts/mw-kube-agent-v3/Chart.yaml
+++ b/charts/mw-kube-agent-v3/Chart.yaml
@@ -15,17 +15,17 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.7.3
+version: 1.7.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.27"
+appVersion: "0.1.28"
 
 dependencies:
   - name: mw-autoinstrumentation
-    version: 1.2.5
+    version: 1.2.6
     repository: https://helm.middleware.io
     condition: mw-autoinstrumentation.enabled
     alias: mw-autoinstrumentation 

--- a/charts/mw-kube-agent-v3/templates/daemonset.yaml
+++ b/charts/mw-kube-agent-v3/templates/daemonset.yaml
@@ -15,21 +15,16 @@ spec:
         integrations.middleware.io/prometheus: "true"
         {{- end }}
     spec:
+      {{- with .Values.daemonset.tolerations }}
       tolerations:
-      # these tolerations are to have the daemonset runnable on control plane nodes
-      # remove them if your control plane nodes should not run pods
-      - key: node-role.kubernetes.io/control-plane
-        operator: Exists
-        effect: NoSchedule
-      - key: node-role.kubernetes.io/master
-        operator: Exists
-        effect: NoSchedule
-      - operator: Exists
-        effect: NoSchedule
-      - operator: Exists
-        effect: NoExecute
-      {{- if .Values.providers.eks.fargate.enabled }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if or .Values.daemonset.affinity .Values.providers.eks.fargate.enabled }}
       affinity:
+        {{- if .Values.daemonset.affinity }}
+        {{- toYaml .Values.daemonset.affinity | nindent 8 }}
+        {{- end }}
+        {{- if .Values.providers.eks.fargate.enabled }}
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
@@ -38,6 +33,11 @@ spec:
                 operator: NotIn
                 values:
                 - fargate
+        {{- end }}
+      {{- end }}
+      {{- with .Values.daemonset.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
       {{- end }}
 
       {{- if .Values.features.enableHostMonitoring }}

--- a/charts/mw-kube-agent-v3/templates/deployment.yaml
+++ b/charts/mw-kube-agent-v3/templates/deployment.yaml
@@ -15,20 +15,18 @@ spec:
         integrations.middleware.io/prometheus: "true"
         {{- end }}
     spec:
+      {{- with .Values.deployment.tolerations }}
       tolerations:
-      # these tolerations are to have the daemonset runnable on control plane nodes
-      # remove them if your control plane nodes should not run pods
-      - key: node-role.kubernetes.io/control-plane
-        operator: Exists
-        effect: NoSchedule
-      - key: node-role.kubernetes.io/master
-        operator: Exists
-        effect: NoSchedule
-      - operator: Exists
-        effect: NoSchedule
-      - operator: Exists
-        effect: NoExecute
-
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: mw-deployment-otel-config-volume
           configMap:

--- a/charts/mw-kube-agent-v3/values.yaml
+++ b/charts/mw-kube-agent-v3/values.yaml
@@ -121,6 +121,21 @@ service:
 
 daemonset:
   name: mw-agent
+  nodeSelector: {}
+  affinity: {}
+  tolerations:
+    # these tolerations are to have the daemonset runnable on control plane nodes
+    # remove them if your control plane nodes should not run pods
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+      effect: NoSchedule
+    - key: node-role.kubernetes.io/master
+      operator: Exists
+      effect: NoSchedule
+    - operator: Exists
+      effect: NoSchedule
+    - operator: Exists
+      effect: NoExecute
   resources:
     requests:
       cpu: "200m" # Default CPU request
@@ -132,6 +147,21 @@ daemonset:
     name: mw-daemonset-otel-config
 deployment:
   name: mw-cluster-agent
+  nodeSelector: {}
+  affinity: {}
+  tolerations:
+    # these tolerations are to have the deployment runnable on control plane nodes
+    # remove them if your control plane nodes should not run pods
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+      effect: NoSchedule
+    - key: node-role.kubernetes.io/master
+      operator: Exists
+      effect: NoSchedule
+    - operator: Exists
+      effect: NoSchedule
+    - operator: Exists
+      effect: NoExecute
   resources:
     requests:
       cpu: "200m" # Default CPU request


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Update Helm chart version to 1.7.4.

- Upgrade `mw-autoinstrumentation` dependency to version 1.2.6.

- Externalize scheduling configurations for DaemonSet and Deployment.
  - Move tolerations, affinity, and nodeSelector to `values.yaml`.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph ChartMetadata["Chart Metadata"]
    C["Chart.yaml"] -- "Bump version to 1.7.4" --> V["Version Update"]
  end
  subgraph Templates["Templates"]
    DS["daemonset.yaml"]
    DEP["deployment.yaml"]
  end
  subgraph Values["Values Configuration"]
    VAL["values.yaml"]
  end
  VAL -- "Injects scheduling configs" --> DS
  VAL -- "Injects scheduling configs" --> DEP
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Chart.yaml</strong><dd><code>Update chart and dependency versions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/mw-kube-agent-v3/Chart.yaml

<ul><li>Incremented chart version from 1.7.3 to 1.7.4.<br> <li> Updated <code>appVersion</code> to 0.1.28.<br> <li> Updated <code>mw-autoinstrumentation</code> dependency version to 1.2.6.</ul>


</details>


  </td>
  <td><a href="https://github.com/middleware-labs/helm-charts/pull/130/files#diff-3fb12cad5913ff555d1e89e84ba6a3c498a84232d3bf221c056eff2653e9c7e2">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>daemonset.yaml</strong><dd><code>Make DaemonSet scheduling configurable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/mw-kube-agent-v3/templates/daemonset.yaml

<ul><li>Replaced hardcoded tolerations with a configurable block from <br><code>.Values.daemonset.tolerations</code>.<br> <li> Added support for custom <code>affinity</code> and <code>nodeSelector</code> from values.<br> <li> Refactored EKS Fargate node affinity logic to coexist with custom <br>affinity.</ul>


</details>


  </td>
  <td><a href="https://github.com/middleware-labs/helm-charts/pull/130/files#diff-11fac7cd288a424a0e1c31ee441c2873d481829b0719e0792029f39bfe509dc9">+13/-13</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>deployment.yaml</strong><dd><code>Make Deployment scheduling configurable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/mw-kube-agent-v3/templates/deployment.yaml

<ul><li>Replaced hardcoded tolerations with configurable values from <br><code>.Values.deployment.tolerations</code>.<br> <li> Added dynamic <code>affinity</code> and <code>nodeSelector</code> support for the agent <br>deployment.</ul>


</details>


  </td>
  <td><a href="https://github.com/middleware-labs/helm-charts/pull/130/files#diff-d63b7abf84289dcd186839dd605520db54bef34fccf663b92a4fb181031c541a">+11/-13</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>values.yaml</strong><dd><code>Define default scheduling parameters in values</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/mw-kube-agent-v3/values.yaml

<ul><li>Added default <code>nodeSelector</code>, <code>affinity</code>, and <code>tolerations</code> blocks for both <br><code>daemonset</code> and <code>deployment</code> sections.<br> <li> Moved previously hardcoded control-plane tolerations into these <br>default values.</ul>


</details>


  </td>
  <td><a href="https://github.com/middleware-labs/helm-charts/pull/130/files#diff-ee1f6cee921bf769682b7c74cc18200bbd581087ad4ff8ed5717bf6a00cdede9">+30/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

